### PR TITLE
fix: incorrect path

### DIFF
--- a/src/RobotLoader/FixerClassProvider.php
+++ b/src/RobotLoader/FixerClassProvider.php
@@ -23,7 +23,7 @@ final class FixerClassProvider
         }
 
         $robotLoader = new RobotLoader();
-        $robotLoader->addDirectory(__DIR__ . '/../../../../vendor/friendsofphp/php-cs-fixer/src');
+        $robotLoader->addDirectory(__DIR__ . '/../../../../friendsofphp/php-cs-fixer/src');
 
         $robotLoader->acceptFiles = ['*Fixer.php'];
         $robotLoader->rebuild();


### PR DESCRIPTION
Conversion of php cs fixer configuration is failing with error

```
File or directory '<my_project_root>/vendor/symplify/sniffer-fixer-to-ecsconverter/src/RobotLoader/../../../../vendor/friendsofphp/php-cs-fixer/src' not found.     
```

Four `..` from `vendor/symplify/sniffer-fixer-to-ecs-converter/src/RobotLoader` takes you to `vendor`.
So there is no need for `vendor` again.

Also, the `vendor` directory name is configurable in composer.json.
